### PR TITLE
adding timeout values to azurerm_private_dns_zone and azurerm_private…

### DIFF
--- a/resources.connectivity.tf
+++ b/resources.connectivity.tf
@@ -450,6 +450,12 @@ resource "azurerm_private_dns_zone" "connectivity" {
     azurerm_resource_group.connectivity,
   ]
 
+  timeouts {
+    create = "120m"
+    update = "120m"
+    read   = "120m"
+  }
+
 }
 
 resource "azurerm_dns_zone" "connectivity" {
@@ -510,6 +516,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "connectivity" {
     azurerm_virtual_network.connectivity,
     azurerm_private_dns_zone.connectivity,
   ]
+
+  timeouts {
+    create = "120m"
+    update = "120m"
+    read   = "120m"
+  }
 
 }
 


### PR DESCRIPTION
…_dns_zone_virtual_network_link - resources.connectivity.tf

<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Adding timeout values when creating, updating or reading tf resources azurerm_private_dns_zone and azurerm_private_dns_zone_virtual_network_link inside root file resources.connectivity.tf.
Some customer have reported problems when deploying larger environments due to timeout problems.
Issues reported: https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/750

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes adds:

1. File: resources.connectivity.tf
2. Resource: azurerm_private_dns_zone -> adding: timeouts
4. Resource: azurerm_private_dns_zone_virtual_network_link -> adding: timeouts

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).
Followed terraform documentation:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link#timeouts
https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
